### PR TITLE
Add dark mode support with theme toggle

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,9 @@
+### my commands
+- npx nuxi dev
+- npx nuxi dev --tunnel
+- npx nuxi dev --host
+- npm run dev (boring and worse)
+
 # Nuxt Minimal Starter
 
 Look at the [Nuxt documentation](https://nuxt.com/docs/getting-started/introduction) to learn more.

--- a/frontend/components/AppHeader.vue
+++ b/frontend/components/AppHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="bg-white shadow-sm border-b border-gray-200">
+  <header class="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex justify-between items-center h-16">
         <!-- Logo -->
@@ -24,6 +24,8 @@
 
         <!-- User Info & Actions -->
         <div class="flex items-center space-x-4">
+          <!-- Theme Toggle -->
+          <ThemeToggle />
           <!-- User Display -->
           <div v-if="authStore.isAuthenticated || authStore.isGuest" class="flex items-center space-x-3">
             <div class="flex items-center space-x-2">

--- a/frontend/components/ThemeToggle.vue
+++ b/frontend/components/ThemeToggle.vue
@@ -1,0 +1,33 @@
+<template>
+  <client-only>
+    <button
+        @click="toggleTheme"
+        :aria-label="`Switch to ${nextTheme} mode`"
+        class="w-12 h-6 flex items-center justify-start rounded-full p-1 bg-gray-300 dark:bg-gray-500 transition-colors duration-300"
+    >
+      <div
+          class="w-4 h-4 bg-white rounded-full shadow transform transition-transform duration-300"
+          :class="isDark ? 'translate-x-6' : 'translate-x-0'"
+      >
+        <component
+            :is="isDark ? MoonIcon : SunIcon"
+            class="w-3 h-3 text-yellow-500 m-auto mt-0.5"
+        />
+      </div>
+    </button>
+  </client-only>
+</template>
+
+<script setup lang="ts">
+import { useColorMode } from '#imports'
+import { computed } from 'vue'
+import { SunIcon, MoonIcon } from '@heroicons/vue/24/solid'
+
+const colorMode = useColorMode()
+const isDark = computed(() => colorMode.value === 'dark')
+const nextTheme = computed(() => isDark.value ? 'light' : 'dark')
+
+function toggleTheme() {
+  colorMode.preference = nextTheme.value
+}
+</script>

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -1,5 +1,12 @@
 <template>
-  <div class="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+  <div
+      class="
+      min-h-screen
+      bg-gradient-to-br from-blue-50 to-indigo-100
+      dark:bg-gradient-to-br dark:from-gray-900 dark:to-gray-800
+      transition-colors duration-300
+    "
+  >
     <AppHeader />
     <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <slot />

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -4,8 +4,15 @@ export default defineNuxtConfig({
     modules: [
         '@nuxtjs/tailwindcss',
         '@pinia/nuxt',
-        '@vueuse/nuxt'
+        '@vueuse/nuxt',
+        '@nuxtjs/color-mode',
     ],
+    colorMode: {
+        classSuffix: '',
+        preference: 'system',
+        fallback: 'light',
+        storageKey: 'color-mode'
+    },
     css: ['~/assets/css/main.css'],
     runtimeConfig: {
         public: {
@@ -16,7 +23,11 @@ export default defineNuxtConfig({
     },
     app: {
         head: {
-            title: 'OAuth App',
+            title: 'zawosite',
+            link : [
+                { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
+                //{ rel: 'icon', type: 'image/png', href: '/myicon.png' },
+            ],
             meta: [
                 { charset: 'utf-8' },
                 { name: 'viewport', content: 'width=device-width, initial-scale=1' }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "@headlessui/vue": "^1.7.16",
         "@heroicons/vue": "^2.0.18",
+        "@nuxtjs/color-mode": "^3.5.2",
         "@nuxtjs/tailwindcss": "^6.8.4",
         "@pinia/nuxt": "^0.5.1",
         "@vueuse/core": "^10.5.0",
@@ -1617,6 +1618,47 @@
       "peerDependencies": {
         "vue": "^3.3.4"
       }
+    },
+    "node_modules/@nuxtjs/color-mode": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/color-mode/-/color-mode-3.5.2.tgz",
+      "integrity": "sha512-cC6RfgZh3guHBMLLjrBB2Uti5eUoGM9KyauOaYS9ETmxNWBMTvpgjvSiSJp1OFljIXPIqVTJ3xtJpSNZiO3ZaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/kit": "^3.13.2",
+        "pathe": "^1.1.2",
+        "pkg-types": "^1.2.1",
+        "semver": "^7.6.3"
+      }
+    },
+    "node_modules/@nuxtjs/color-mode/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
+    },
+    "node_modules/@nuxtjs/color-mode/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "license": "MIT"
+    },
+    "node_modules/@nuxtjs/color-mode/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/@nuxtjs/color-mode/node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
     },
     "node_modules/@nuxtjs/tailwindcss": {
       "version": "6.14.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,16 +10,17 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "nuxt": "^3.17.5",
-    "vue": "^3.5.17",
-    "vue-router": "^4.5.1",
+    "@headlessui/vue": "^1.7.16",
+    "@heroicons/vue": "^2.0.18",
+    "@nuxtjs/color-mode": "^3.5.2",
+    "@nuxtjs/tailwindcss": "^6.8.4",
     "@pinia/nuxt": "^0.5.1",
     "@vueuse/core": "^10.5.0",
     "@vueuse/nuxt": "^10.5.0",
+    "nuxt": "^3.17.5",
     "pinia": "^2.1.7",
-    "@nuxtjs/tailwindcss": "^6.8.4",
-    "@headlessui/vue": "^1.7.16",
-    "@heroicons/vue": "^2.0.18",
+    "vue": "^3.5.17",
+    "vue-router": "^4.5.1",
     "vue-toastification": "^2.0.0-rc.5",
     "vue3-google-login": "^2.0.21"
   },

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,3 +1,4 @@
+export const darkMode = 'class';
 export const content = [
     "./components/**/*.{js,vue,ts}",
     "./layouts/**/*.vue",


### PR DESCRIPTION
Integrated @nuxtjs/color-mode for dark mode support and added a ThemeToggle component to the header. Updated layout and header styles to support dark mode, and adjusted Nuxt config and Tailwind config for color mode handling. Updated dependencies to include @nuxtjs/color-mode.